### PR TITLE
feat: add route-aware Breadcrumbs component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+* **navigation:** add route-aware `Breadcrumbs` component
+
 ## [1.1.2](https://github.com/iamgp/dash_dashkit/compare/dash-dashkit-v1.1.1...dash-dashkit-v1.1.2) (2025-08-20)
 
 

--- a/src/dashkit/__init__.py
+++ b/src/dashkit/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from flask import send_from_directory
 
+from .breadcrumbs import Breadcrumbs
 from .buttons import PrimaryButton, SecondaryButton
 from .callout import (
     Callout,
@@ -112,6 +113,7 @@ __all__ = [
     "create_layout",
     "create_sidebar",
     "create_header",
+    "Breadcrumbs",
     "Table",
     "TableWithStats",
     "PrimaryButton",

--- a/src/dashkit/breadcrumbs.py
+++ b/src/dashkit/breadcrumbs.py
@@ -1,0 +1,123 @@
+"""Breadcrumb navigation component."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import dash_iconify
+from dash import Input, Output, callback, dcc, html, page_registry
+
+
+@dataclass
+class Crumb:
+    """Data for a single breadcrumb."""
+
+    label: str
+    icon: str | None = None
+    href: str | None = None
+
+
+def Breadcrumbs(id: str = "breadcrumbs") -> html.Nav:
+    """Render the breadcrumb container.
+
+    This returns an empty ``Nav`` element that will be populated via a
+    callback whenever the URL changes.
+
+    Pages can override labels, icons, or hide specific crumbs by passing a
+    ``breadcrumbs`` list to :func:`dash.register_page`. Each item should have
+    a ``path`` key and optional ``label``, ``icon``, or ``hide`` keys.
+    """
+
+    return html.Nav(
+        id=id,
+        className="flex items-center gap-1 text-sm px-4 py-2 text-dashkit-text dark:text-dashkit-text-invert",
+    )
+
+
+@callback(Output("breadcrumbs", "children"), Input("url", "pathname"))
+def _update_breadcrumbs(pathname: str | None) -> list[Any]:
+    """Update breadcrumb trail based on current pathname."""
+
+    if pathname is None:
+        return []
+
+    # Locate current page entry
+    current_page: dict[str, Any] | None = None
+    for page in page_registry.values():
+        if page.get("path") == pathname:
+            current_page = page
+            break
+
+    # Map overrides by path for quick lookup
+    override_map: dict[str, dict[str, Any]] = {}
+    if current_page and current_page.get("breadcrumbs"):
+        for override in current_page.get("breadcrumbs", []):
+            path = override.get("path")
+            if path:
+                override_map[path] = override
+
+    crumbs: list[Crumb] = [Crumb(label="Home", icon="home", href="/")]
+
+    parts = [p for p in pathname.strip("/").split("/") if p]
+    path_accum = ""
+    for part in parts:
+        path_accum += "/" + part
+        page = next(
+            (p for p in page_registry.values() if p.get("path") == path_accum), None
+        )
+        label = (
+            page.get("name") or page.get("title")
+            if page
+            else part.replace("-", " ").title()
+        )
+        icon = page.get("icon") if page else None
+
+        if override := override_map.get(path_accum):
+            label = override.get("label", label)
+            icon = override.get("icon", icon)
+            if override.get("hide"):
+                continue
+
+        crumbs.append(Crumb(label=label, icon=icon, href=path_accum))
+
+    # Current page should not be a link
+    if crumbs:
+        crumbs[-1].href = None
+
+    elements: list[Any] = []
+    for idx, crumb in enumerate(crumbs):
+        icon_elem = (
+            dash_iconify.DashIconify(
+                icon=crumb.icon if ":" in crumb.icon else f"mynaui:{crumb.icon}",
+                width=14,
+                className="mr-1",
+            )
+            if crumb.icon
+            else None
+        )
+        label_elem = html.Span(crumb.label)
+
+        if crumb.href:
+            link = dcc.Link(
+                [icon_elem, label_elem] if icon_elem else label_elem,
+                href=crumb.href,
+                className="flex items-center hover:underline",
+            )
+            elements.append(link)
+        else:
+            elements.append(
+                html.Span(
+                    [icon_elem, label_elem] if icon_elem else label_elem,
+                    className="flex items-center",
+                )
+            )
+
+        if idx < len(crumbs) - 1:
+            elements.append(
+                dash_iconify.DashIconify(
+                    icon="mynaui:chevron-right",
+                    width=12,
+                    className="mx-1 text-dashkit-icon-light dark:text-dashkit-icon-dark",
+                )
+            )
+
+    return elements

--- a/src/dashkit/layout.py
+++ b/src/dashkit/layout.py
@@ -4,6 +4,7 @@ import dash
 import dash_mantine_components as dmc
 from dash import Input, Output, callback, clientside_callback, dcc, html
 
+from .breadcrumbs import Breadcrumbs
 from .header import create_header
 from .sidebar import create_sidebar
 from .theme_manager import ThemeManager
@@ -80,6 +81,7 @@ def create_layout(
                             actions=header_config.get("actions"),
                             filter_items=header_config.get("filter_items"),
                         ),
+                        Breadcrumbs(),
                         # Content with max-width constraint
                         html.Main(
                             [


### PR DESCRIPTION
## Summary
- add `Breadcrumbs` component that builds navigation trail from Dash `page_registry`
- insert breadcrumb trail below header in default layout
- expose `Breadcrumbs` from package and document in changelog

## Testing
- `uv run --group dev task check`

------
https://chatgpt.com/codex/tasks/task_e_68b44407fbe48321ab5cdbfa41d77e62